### PR TITLE
Display color emoji in the notification title

### DIFF
--- a/HealthMeter/Service/RestingHeartRateService.swift
+++ b/HealthMeter/Service/RestingHeartRateService.swift
@@ -294,7 +294,8 @@ class RestingHeartRateService {
     }
 
     func notificationTitle(trend: Trend, heartRate: Double, averageHeartRate: Double) -> String {
-        return trend.displayText
+        let emoji = colorEmojiForLevel(heartRateLevelForMultiplier(multiplier: heartRate / averageHeartRate))
+        return "\(emoji) \(trend.displayText)"
     }
 
     func notificationMessage(trend: Trend, heartRate: Double, averageHeartRate: Double) -> String? {
@@ -449,6 +450,22 @@ class RestingHeartRateService {
             }
         } else {
             return "Your resting heart rate is normal."
+        }
+    }
+
+    func heartRateLevelForMultiplier(multiplier: Double) -> HeartRateLevel {
+        if multiplier > 1.05 {
+            if multiplier > 1.2 {
+                return .wayAboveElevated
+            } else if multiplier > 1.1 {
+                return .noticeablyElevated
+            } else {
+                return .slightlyElevated
+            }
+        } else if multiplier < 0.95 {
+            return .belowAverage
+        } else {
+            return .normal
         }
     }
 

--- a/HealthMeter/Util/Color+level.swift
+++ b/HealthMeter/Util/Color+level.swift
@@ -17,3 +17,13 @@ func colorForLevel(_ level: HeartRateLevel?) -> Color {
     case nil: return .gray
     }
 }
+
+func colorEmojiForLevel(_ level: HeartRateLevel) -> String {
+    switch level {
+    case .belowAverage: return "🟦"
+    case .normal: return "🟩"
+    case .slightlyElevated: return "🟨"
+    case .noticeablyElevated: return "🟧"
+    case .wayAboveElevated: return "🟥"
+    }
+}

--- a/HealthMeterTests/RestingHeartRateServiceTests.swift
+++ b/HealthMeterTests/RestingHeartRateServiceTests.swift
@@ -442,6 +442,27 @@ class RestingHeartRateServiceTests: XCTestCase {
 
         waitForExpectations(timeout: 2.0, handler: .none)
     }
+
+    // MARK: - Multipliers and colors
+    
+    func testHeartRateLevelForMultiplier() {
+        let service = RestingHeartRateService()
+        XCTAssertEqual(service.heartRateLevelForMultiplier(multiplier: 50.0/50.0), .normal)
+        XCTAssertEqual(service.heartRateLevelForMultiplier(multiplier: 20.0/50.0), .belowAverage)
+        XCTAssertEqual(service.heartRateLevelForMultiplier(multiplier: 55.0/50.0), .slightlyElevated)
+        XCTAssertEqual(service.heartRateLevelForMultiplier(multiplier: 60.0/50.0), .noticeablyElevated)
+        XCTAssertEqual(service.heartRateLevelForMultiplier(multiplier: 85.0/50.0), .wayAboveElevated)
+    }
+
+    func testNotificationTitleContainsColorEmoji() {
+        let service = RestingHeartRateService()
+        XCTAssertTrue(service.notificationTitle(trend: .lowering, heartRate: 30, averageHeartRate: 50).contains("🟦"))
+        XCTAssertTrue(service.notificationTitle(trend: .rising, heartRate: 50, averageHeartRate: 50).contains("🟩"))
+        XCTAssertTrue(service.notificationTitle(trend: .rising, heartRate: 53, averageHeartRate: 50).contains("🟨"))
+        XCTAssertTrue(service.notificationTitle(trend: .rising, heartRate: 56, averageHeartRate: 50).contains("🟧"))
+        XCTAssertTrue(service.notificationTitle(trend: .rising, heartRate: 70, averageHeartRate: 50).contains("🟥"))
+        XCTAssertTrue(service.notificationTitle(trend: .rising, heartRate: 100, averageHeartRate: 50).contains("🟥"))
+    }
 }
 
 // MARK: - Mock classes


### PR DESCRIPTION
Display a color emoji square at the beginning of the title of the notification about the elevated RHR.